### PR TITLE
silencing node-ipc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-lib-phantomjs-istanbul",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-lib-puppeteer-istanbul",
   "description": "Grunt and Puppeteer, sitting in a tree for istanbul based code coverage.",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "homepage": "https://github.com/lee-leonardo/grunt-lib-puppeteer-istanbul",
   "author": {
     "name": "Leonardo Lee",

--- a/src/puppeteer-consumer.js
+++ b/src/puppeteer-consumer.js
@@ -2,6 +2,7 @@ const ipc = require('node-ipc');
 
 ipc.config.id = 'consumer';
 ipc.config.retry = 1000;
+ipc.config.silent = true;
 ipc.config.maxRetries = 5;
 ipc.config.maxConnections = 1;
 

--- a/src/puppeteer-eventEmitter.js
+++ b/src/puppeteer-eventEmitter.js
@@ -32,6 +32,7 @@ class PuppeteerEventListener extends EventEmitter {
     super();
 
     ipc.config.id = 'puppeteerConsumer:' + options.url;
+    ipc.config.silent = true || options.verbose;
     ipc.config.retry = 1500;
     ipc.config.maxConnections = 1;
     ipc.config.maxRetries = 5;


### PR DESCRIPTION
Verbose logging is on by default.
This is to reduce noise from the plugin for the task.